### PR TITLE
fix column width

### DIFF
--- a/Resources/views/Collector/hydrations.html.twig
+++ b/Resources/views/Collector/hydrations.html.twig
@@ -74,7 +74,7 @@
                     Entities<span></span></th>
                 <th onclick="javascript:sortTable(this, 3, 'hydrations')" style="cursor: pointer;">
                     Type<span></span></th>
-                <th style="width: 100%;">Alias Map</th>
+                <th>Alias Map</th>
             </tr>
             </thead>
             <tbody id="hydrations">


### PR DESCRIPTION
On the Hydrations profiler view.
Remove 'Alias Map' column's 100% width, so other columns can stretch normally.

![screenshot from 2017-02-17 10-03-26](https://cloud.githubusercontent.com/assets/10633476/23054601/59e4e6c6-f4fa-11e6-836e-e88d4e78fd72.png)