### PR TITLE
Symfony 5 and doctrine-bundle v2 compatibility

### DIFF
--- a/DataCollector/HydrationDataCollector.php
+++ b/DataCollector/HydrationDataCollector.php
@@ -31,7 +31,7 @@ class HydrationDataCollector extends DataCollector
         $this->hydrationLogger = $manager->getConfiguration()->getHydrationLogger();
     }
 
-    public function collect(Request $request, Response $response, \Exception $exception = null)
+    public function collect(Request $request, Response $response, \Throwable $exception = null)
     {
         $this->data['hydrations'] = $this->hydrationLogger->hydrations;
     }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,13 +17,10 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('debesha_doctrine_profile_extra');
-
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for
         // more information on that topic.
 
-        return $treeBuilder;
+        return new TreeBuilder('debesha_doctrine_profile_extra');
     }
 }

--- a/ORM/LoggingEntityManager.php
+++ b/ORM/LoggingEntityManager.php
@@ -51,7 +51,7 @@ class LoggingEntityManager extends EntityManager
     }
 
     /**
-     * @return LoggingConfiguration
+     * @return Configuration
      */
     public function getConfiguration()
     {
@@ -81,7 +81,7 @@ class LoggingEntityManager extends EntityManager
                 break;
 
             default:
-                throw new \InvalidArgumentException('Invalid argument: '.$conn);
+                throw new \InvalidArgumentException('Invalid argument');
         }
 
         return new self($conn, $config, $conn->getEventManager());

--- a/ORM/LoggingHydratorTrait.php
+++ b/ORM/LoggingHydratorTrait.php
@@ -13,6 +13,7 @@
 
 namespace Debesha\DoctrineProfileExtraBundle\ORM;
 
+use Countable;
 use Doctrine\ORM\Internal\Hydration\ArrayHydrator;
 use Doctrine\ORM\Internal\Hydration\ObjectHydrator;
 use Doctrine\ORM\Internal\Hydration\ScalarHydrator;
@@ -24,7 +25,7 @@ trait LoggingHydratorTrait
     /**
      * Hydrates all rows returned by the passed statement instance at once.
      *
-     * @param \Doctrine\DBAL\Driver\Statement      $stmt
+     * @param \Doctrine\DBAL\Result $stmt
      * @param \Doctrine\ORM\Query\ResultSetMapping $resultSetMapping
      * @param array                                $hints
      *

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,15 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": ">=7.0",
         "doctrine/orm": "^2.2",
-        "doctrine/doctrine-bundle": "^1.2",
-        "symfony/framework-bundle": "^2.1|^3.0|^4.0",
-        "symfony/twig-bundle": "^2.0|^3.0|^4.0",
+        "doctrine/doctrine-bundle": "^1.2|^2.0",
+        "symfony/framework-bundle": "^2.1|^3.0|^4.0|^5.0",
+        "symfony/twig-bundle": "^2.0|^3.0|^4.0|^5.0",
         "twig/twig": "^1.12|^2.0"
+    },
+    "require-dev": {
+        "roave/security-advisories": "dev-latest"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- Added support for Symfony 5

- Updated PHP to version 7 to support the updated interfaces in Doctrine Bundle v2.

