### PR TITLE
fix: deprecation warning newHydrator

### DIFF
--- a/ORM/LoggingEntityManager.php
+++ b/ORM/LoggingEntityManager.php
@@ -22,13 +22,14 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\ORMException;
 use Doctrine\ORM\Query;
 use Doctrine\DBAL\Connection;
+use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
 
 class LoggingEntityManager extends EntityManager
 {
     /**
      * {@inheritdoc}
      */
-    public function newHydrator($hydrationMode)
+    public function newHydrator($hydrationMode): AbstractHydrator
     {
         switch ($hydrationMode) {
             case Query::HYDRATE_OBJECT:


### PR DESCRIPTION
Solves warning:

`Method "Doctrine\ORM\EntityManagerInterface::newHydrator()" might add "AbstractHydrator" as a native return type declaration in the future. Do the same in implementation "Debesha\DoctrineProfileExtraBundle\ORM\LoggingEntityManager" now to avoid errors or add an explicit @return annotation to suppress this message.`