### PR TITLE
fix: deprecate warning create with EntityManager

### DIFF
--- a/ORM/LoggingEntityManager.php
+++ b/ORM/LoggingEntityManager.php
@@ -61,7 +61,7 @@ class LoggingEntityManager extends EntityManager
     /**
      * {@inheritdoc}
      */
-    public static function create($conn, Configuration $config, EventManager $eventManager = null)
+    public static function create($conn, Configuration $config, EventManager $eventManager = null): EntityManager
     {
         if (!$config->getMetadataDriverImpl()) {
             throw ORMException::missingMappingDriverImpl();


### PR DESCRIPTION
Solves warning:

`Method "Doctrine\ORM\EntityManager::create()" might add "EntityManager" as a native return type declaration in the future. Do the same in child class "Debesha\DoctrineProfileExtraBundle\ORM\LoggingEntityManager" now to avoid errors or add an explicit @return annotation to suppress this message.`