### PR TITLE
fix: avoid deprecation EntityManager

### DIFF
--- a/ORM/LoggingEntityManager.php
+++ b/ORM/LoggingEntityManager.php
@@ -18,13 +18,13 @@ namespace Debesha\DoctrineProfileExtraBundle\ORM;
 
 use Doctrine\Common\EventManager;
 use Doctrine\ORM\Configuration;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\ORMException;
 use Doctrine\ORM\Query;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
 
-class LoggingEntityManager extends EntityManager
+class LoggingEntityManager extends EntityManagerInterface
 {
     /**
      * {@inheritdoc}
@@ -62,7 +62,7 @@ class LoggingEntityManager extends EntityManager
     /**
      * {@inheritdoc}
      */
-    public static function create($conn, Configuration $config, EventManager $eventManager = null): EntityManager
+    public static function create($conn, Configuration $config, EventManager $eventManager = null): EntityManagerInterface
     {
         if (!$config->getMetadataDriverImpl()) {
             throw ORMException::missingMappingDriverImpl();


### PR DESCRIPTION
Solves the deprecation error:

`The "Doctrine\ORM\EntityManager" class is considered final. It may change without further notice as of its next major version. You should not extend it from "Debesha\DoctrineProfileExtraBundle\ORM\LoggingEntityManager".`