### PR TITLE
Support multiple entity managers

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -14,7 +14,7 @@
     <services>
         <service id="debesha.doctrine_extra_profiler.data_collector"
                  class="Debesha\DoctrineProfileExtraBundle\DataCollector\HydrationDataCollector" public="false">
-            <argument type="service" id="doctrine.orm.entity_manager"/>
+            <argument type="service" id="doctrine"/>
             <tag name="data_collector" template="@DebeshaDoctrineProfileExtra/Collector/hydrations.html.twig"
                  id="hydrations"/>
         </service>


### PR DESCRIPTION
Injecting the ManagerRegistry gives us access to the entire set of entity managers; this means we can loop through them and collect all available data.

In projects with multiple entity managers, currently only the first entity manager will be used for data collection, which gives an incomplete picture of the total hydration work done.