### PR TITLE
Add support for Doctrine ORM 3

### DIFF
--- a/ORM/LoggingHydratorTrait.php
+++ b/ORM/LoggingHydratorTrait.php
@@ -33,9 +33,12 @@ trait LoggingHydratorTrait
      *
      * @return mixed[]
      */
-    public function hydrateAll(/* Result */$stmt, /*ResultSetMapping*/ $resultSetMapping, /*array*/ $hints = [])/*: Countable|array*/
+    public function hydrateAll(Result $stmt, ResultSetMapping $resultSetMapping, array $hints = []): mixed
     {
-        if ($logger = $this->_em->getConfiguration()->getHydrationLogger()) {
+        // For ORM 2.0 and 3.0 compatibility
+        $entityManager = isset($this->em) ? $this->em : $this->_em;
+
+        if ($logger = $this->em->getConfiguration()->getHydrationLogger()) {
             $type = null;
 
             if ($this instanceof ObjectHydrator) {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=8.0",
-        "doctrine/orm": "^2.19",
+        "doctrine/orm": "^2.19|^3.0",
         "doctrine/doctrine-bundle": "^2.11",
         "symfony/framework-bundle": "^5.4|^6.0|^7.0",
         "symfony/twig-bundle": "^5.4|^6.0|^7.0",


### PR DESCRIPTION
This allows installation on Doctrine ORM 3 and adjusts an overridden method for ORM 3 compatibility.

**This is untested on ORM 2.**

I am unsure how you'd like to handle this upgrade. In my opinion this can go either of two ways:
1. We use the Symfony service container to dynamically swap between two implementations depending on what version is installed,
2. We refactor the code to not override Doctrine methods to ensure compatibility (using middlewares instead?)

What do you think?